### PR TITLE
Make Mesh Renderers and Rigid Bodies properly ECS

### DIFF
--- a/ggp-engine/ComponentManager.cpp
+++ b/ggp-engine/ComponentManager.cpp
@@ -49,5 +49,6 @@ void ECS::ComponentManager::CleanupAllComponents()
             }         
         }
     }
+
     ComponentCount = 0;
 }

--- a/ggp-engine/DebugScene.cpp
+++ b/ggp-engine/DebugScene.cpp
@@ -20,7 +20,6 @@ using namespace std;
 void DebugScene::Init()
 {
     Scene::Init();
-    physicsManager = Physics::PhysicsManager::GetInstance();
 
     //We only need a single material for all three for now
     Material* stoneMaterial = resourceManager->AddMaterial( "stoneMat",
@@ -50,7 +49,7 @@ void DebugScene::Init()
     //Give it the first mesh we made.  In the future, meshes will be managed by the MeshRenderer
     PhysObject->GetComponent<MeshRenderer>( CompType::MESH_RENDERER )->SetMesh( mesh3 );
     PhysObject->GetComponent<MeshRenderer>( CompType::MESH_RENDERER )->SetMaterial( metalMaterial );
-    PhysObject->AddRigidBody( 0.7f, EPhysicsLayer::MOVEABLE );
+    PhysObject->AddComponent<RigidBody>( PhysObject, 0.7f, EPhysicsLayer::MOVEABLE );
 
     PhysObject->AddComponent<ECS::TestComponent>( 999 );
 
@@ -66,9 +65,8 @@ void DebugScene::Init()
     //Give it the first mesh we made.  In the future, meshes will be managed by the MeshRenderer
     PhysObject2->GetComponent<MeshRenderer>( CompType::MESH_RENDERER )->SetMesh( mesh3 );
     PhysObject2->GetComponent<MeshRenderer>( CompType::MESH_RENDERER )->SetMaterial( blueMatte );
-    PhysObject2->AddRigidBody( 0.7f, EPhysicsLayer::MOVEABLE );
     PhysObject2->transform.position.y = 3.f;
-
+    PhysObject2->AddComponent<RigidBody>( PhysObject2, 0.7f, EPhysicsLayer::MOVEABLE );
 
 
     //Create a light
@@ -113,7 +111,7 @@ void DebugScene::Update( float _deltaTime )
 
 
     // Loops throught the active rigid bodies and checks for ray hits
-    for ( UINT i = 0; i < physicsManager->GetRigidBodyCount(); ++i )
+    /*for ( UINT i = 0; i < physicsManager->GetRigidBodyCount(); ++i )
     {
         RigidBody* _rb = physicsManager->GetRigidBody( i );
         Physics::Point rayOrigin = {};
@@ -127,11 +125,10 @@ void DebugScene::Update( float _deltaTime )
 
         int result = Physics::Collisions::IntersectRaySphere( rayOrigin, rayDir, _rb->GetCollider(), t, hitPoint );
         // TODO: Draw the ray
-    }
+    }*/
 
     // For every physics object in the scene
     // Update the physics
-    physicsManager->UpdatePhysics( _deltaTime );
     // Check collisions
 
 }

--- a/ggp-engine/DebugScene.cpp
+++ b/ggp-engine/DebugScene.cpp
@@ -45,10 +45,13 @@ void DebugScene::Init()
 
     GameObject* PhysObject = new GameObject( "PhysObject" );
     AddChild( PhysObject );
-    PhysObject->AddMeshRenderer();
-    //Give it the first mesh we made.  In the future, meshes will be managed by the MeshRenderer
-    PhysObject->GetComponent<MeshRenderer>( CompType::MESH_RENDERER )->SetMesh( mesh3 );
-    PhysObject->GetComponent<MeshRenderer>( CompType::MESH_RENDERER )->SetMaterial( metalMaterial );
+
+    MeshRenderer* aMesh = PhysObject->AddComponent<MeshRenderer>( PhysObject );
+    if ( aMesh != nullptr )
+    {
+        aMesh->SetMesh( mesh3 );
+        aMesh->SetMaterial( metalMaterial );
+    }
     PhysObject->AddComponent<RigidBody>( PhysObject, 0.7f, EPhysicsLayer::MOVEABLE );
 
     PhysObject->AddComponent<ECS::TestComponent>( 999 );
@@ -61,10 +64,13 @@ void DebugScene::Init()
 
     GameObject* PhysObject2 = new GameObject( "PhysObject2" );
     AddChild( PhysObject2 );
-    PhysObject2->AddMeshRenderer();
-    //Give it the first mesh we made.  In the future, meshes will be managed by the MeshRenderer
-    PhysObject2->GetComponent<MeshRenderer>( CompType::MESH_RENDERER )->SetMesh( mesh3 );
-    PhysObject2->GetComponent<MeshRenderer>( CompType::MESH_RENDERER )->SetMaterial( blueMatte );
+    aMesh = PhysObject2->AddComponent<MeshRenderer>( PhysObject2 );
+    if ( aMesh != nullptr )
+    {
+        aMesh->SetMesh( mesh3 );
+        aMesh->SetMaterial( blueMatte );
+    }
+    
     PhysObject2->transform.position.y = 3.f;
     PhysObject2->AddComponent<RigidBody>( PhysObject2, 0.7f, EPhysicsLayer::MOVEABLE );
 

--- a/ggp-engine/Game.cpp
+++ b/ggp-engine/Game.cpp
@@ -118,7 +118,7 @@ void Game::Update(float deltaTime, float totalTime) {
 	HandleMouseMove();
 
 	inputManager->Update();
-
+    physicsManager->UpdatePhysics( deltaTime );
 	activeScene->Update(deltaTime);
 }
 

--- a/ggp-engine/Game.cpp
+++ b/ggp-engine/Game.cpp
@@ -80,8 +80,8 @@ void Game::Init() {
 	ResourceManager::SetContextPointer(dxContext);
 
 	//Create and init the active scene
-	//activeScene = new PBRDemoScene("PBR_Demo");
-    activeScene = new DebugScene( "Debug Scene" );
+	activeScene = new PBRDemoScene("PBR_Demo");
+    //activeScene = new DebugScene( "Debug Scene" );
 	activeScene->Init();
 
 	// Tell the input assembler stage of the pipeline what kind of

--- a/ggp-engine/GameObject.cpp
+++ b/ggp-engine/GameObject.cpp
@@ -166,10 +166,10 @@ void GameObject::AddMeshRenderer() {
 void GameObject::AddPointLight( DirectX::XMFLOAT4 _color ) {
     components[ CompType::POINT_LIGHT ] = lightManager->AddPointLight( this, _color );
 }
-
+/*
 void GameObject::AddRigidBody( float aMass, EPhysicsLayer aLayer ) {
     components[ CompType::RIGID_BODY ] = physicsManager->AddRigidBody( this, aMass, aLayer );
-}
+}*/
 
 string GameObject::GetUniqueID() { return uniqueID; }
 

--- a/ggp-engine/GameObject.cpp
+++ b/ggp-engine/GameObject.cpp
@@ -158,10 +158,10 @@ void GameObject::AddInputListener() {
 void GameObject::AddDirLight(DirectX::XMFLOAT4 _color, DirectX::XMFLOAT3 _direction, float _diffuseIntensity, float _ambientIntensity) {
 	components[CompType::DIRECTIONAL_LIGHT] = lightManager->AddDirLight(this, _color, _direction, _diffuseIntensity, _ambientIntensity);
 }
-
+/*
 void GameObject::AddMeshRenderer() {
     components[ CompType::MESH_RENDERER ] = renderManager->AddMeshRenderer( this );
-}
+}*/
 
 void GameObject::AddPointLight( DirectX::XMFLOAT4 _color ) {
     components[ CompType::POINT_LIGHT ] = lightManager->AddPointLight( this, _color );

--- a/ggp-engine/GameObject.h
+++ b/ggp-engine/GameObject.h
@@ -17,17 +17,12 @@
 #include "InputEvent.h"
 #include "InputManager.h"
 #include "LightManager.h"
-#include "PhysicsManager.h"
 #include "Transform.h"
 #include "ComponentManager.h"
 
 class ResourceManager;
 class RenderManager;
-/*
-namespace ECS
-{
-    class ComponentManager;
-}*/
+
 
 typedef unsigned int UINT;
 
@@ -63,7 +58,6 @@ protected:
     InputManager* inputManager;
     ResourceManager* resourceManager;
     LightManager* lightManager;
-    Physics::PhysicsManager * physicsManager;
 
     ECS::ComponentManager * componentManager = nullptr;
 
@@ -201,7 +195,7 @@ public:
     void AddDirLight( DirectX::XMFLOAT4 _color = DirectX::XMFLOAT4( 1.0f, 1.0f, 1.0f, 1.0f ), DirectX::XMFLOAT3 _direction = DirectX::XMFLOAT3( 0.0f, 1.0f, 0.0f ), float _diffuseIntensity = 1.0f, float _ambientIntensity = 0.0f );
     void AddMeshRenderer();
     void AddPointLight( DirectX::XMFLOAT4 _color = DirectX::XMFLOAT4( 1.0f, 1.0f, 1.0f, 1.0f ) );
-    void AddRigidBody( float aMass, EPhysicsLayer aLayer );
+    //void AddRigidBody( float aMass, EPhysicsLayer aLayer );
 
     //Gets for member variables
     std::string GetUniqueID();

--- a/ggp-engine/GameObject.h
+++ b/ggp-engine/GameObject.h
@@ -192,9 +192,7 @@ public:
     //Functions to add different types of components
     void AddInputListener();
     void AddDirLight( DirectX::XMFLOAT4 _color = DirectX::XMFLOAT4( 1.0f, 1.0f, 1.0f, 1.0f ), DirectX::XMFLOAT3 _direction = DirectX::XMFLOAT3( 0.0f, 1.0f, 0.0f ), float _diffuseIntensity = 1.0f, float _ambientIntensity = 0.0f );
-    void AddMeshRenderer();
     void AddPointLight( DirectX::XMFLOAT4 _color = DirectX::XMFLOAT4( 1.0f, 1.0f, 1.0f, 1.0f ) );
-    //void AddRigidBody( float aMass, EPhysicsLayer aLayer );
 
     //Gets for member variables
     std::string GetUniqueID();

--- a/ggp-engine/GameObject.h
+++ b/ggp-engine/GameObject.h
@@ -23,7 +23,6 @@
 class ResourceManager;
 class RenderManager;
 
-
 typedef unsigned int UINT;
 
 class GameObject

--- a/ggp-engine/MeshRenderer.cpp
+++ b/ggp-engine/MeshRenderer.cpp
@@ -5,21 +5,23 @@
 #include "Material.h"
 #include "Mesh.h"
 #include "GameObject.h"
+#include "RenderManager.h"
 
-MeshRenderer::MeshRenderer(UINT _uniqueID, GameObject* _gameObject) {
-	type = CompType::MESH_RENDERER;
-	uniqueID = _uniqueID;
+MeshRenderer::MeshRenderer(GameObject* _gameObject) {
 	gameObject = _gameObject;
+
+    owner = _gameObject->GetUniqueID();
 	mesh = nullptr;
 	material = nullptr;
+    RenderManager::GetInstance()->AddMeshRenderer( this );
 }
 
-MeshRenderer::MeshRenderer(UINT _uniqueID, GameObject* _gameObject, Mesh* _mesh, Material* _material) {
-	type = CompType::MESH_RENDERER;
-	uniqueID = _uniqueID;
+MeshRenderer::MeshRenderer( GameObject* _gameObject, Mesh* _mesh, Material* _material) {
 	gameObject = _gameObject;
+    owner = _gameObject->GetUniqueID();
 	mesh = _mesh;
 	material = _material;
+    RenderManager::GetInstance()->AddMeshRenderer( this );
 }
 
 MeshRenderer::~MeshRenderer() {}

--- a/ggp-engine/MeshRenderer.h
+++ b/ggp-engine/MeshRenderer.h
@@ -6,19 +6,24 @@
 #include <DirectXMath.h>
 #include <d3d11.h>
 #include "Component.h"
+#include "BaseComponent.h"
+
 class Mesh;
 class Material;
 class GameObject;
 class SimpleVertexShader;
 class SimplePixelShader;
+class RenderManager;
 
-class MeshRenderer : public Component {
+class MeshRenderer 
+    : public ECS::BaseComponent<MeshRenderer>
+{
 	Mesh* mesh;
 	Material* material;
 public:
     //GameObject * gameObject;
-	MeshRenderer(UINT _uniqueID, GameObject* _gameObject);
-	MeshRenderer(UINT _uniqueID, GameObject* _gameObject, Mesh* _mesh, Material* _material);
+	MeshRenderer(GameObject* _gameObject);
+	MeshRenderer(GameObject* _gameObject, Mesh* _mesh, Material* _material);
 	~MeshRenderer();
 
 	void SetMesh(Mesh* _mesh);
@@ -33,6 +38,9 @@ public:
 	SimpleVertexShader* GetVertexShader();
 	SimplePixelShader* GetPixelShader();
 	DirectX::XMFLOAT4 GetColor();
+
+    GameObject* gameObject;
+    UINT uniqueID;
 };
 
 #endif //GGP_MESH_RENDERER_H

--- a/ggp-engine/PBRDemoScene.cpp
+++ b/ggp-engine/PBRDemoScene.cpp
@@ -31,9 +31,13 @@ void PBRDemoScene::Init() {
 	for (UINT i = 0; i < 7; i++) {
 		GameObject* newSphere = new GameObject("Sphere");
 		AddChild(newSphere);
-		newSphere->AddMeshRenderer();
-		newSphere->GetComponent<MeshRenderer>(CompType::MESH_RENDERER)->SetMesh(sphereMesh);
-		newSphere->GetComponent<MeshRenderer>(CompType::MESH_RENDERER)->SetMaterial(pbrMats[i]);
+        MeshRenderer* aMeshRend = newSphere->AddComponent<MeshRenderer>( newSphere );
+        if ( aMeshRend )
+        {
+            aMeshRend->SetMesh( sphereMesh );
+            aMeshRend->SetMaterial( pbrMats[ i ] );
+        }
+
 		newSphere->transform.position.x = (float)i * 1.2f;
 	}
 

--- a/ggp-engine/PhysicsManager.cpp
+++ b/ggp-engine/PhysicsManager.cpp
@@ -64,7 +64,16 @@ UINT PhysicsManager::AddRigidBody( GameObject* aGameObj, float aMass, EPhysicsLa
     // #FixForNextBuild
     // Whyyyyy does this happen? I shouldn't have to put instance in front of this
     Instance->RigidBodyUIDMap.insert( std::pair<UINT, RigidBody*>( Instance->rBodyCount, rb ) );
-    
+
+    return Instance->rBodyCount++;
+}
+
+UINT Physics::PhysicsManager::AddRigidBody( GameObject * aGameObj, RigidBody * aRigidBody )
+{
+    assert( aRigidBody != nullptr && aGameObj != nullptr );
+
+    Instance->RigidBodyUIDMap.insert( std::pair<UINT, RigidBody*>( Instance->rBodyCount, aRigidBody ) );
+
     return Instance->rBodyCount++;
 }
 
@@ -72,13 +81,14 @@ RigidBody * PhysicsManager::GetRigidBody( UINT uID )
 {
     auto thisRB = RigidBodyUIDMap.find( uID );
     //If found, return it.  Else, return nullptr
-    if ( thisRB != RigidBodyUIDMap.end() ) {
+    if ( thisRB != RigidBodyUIDMap.end() )
+    {
         return thisRB->second;
     }
     return nullptr;
 }
 
-/** Iteration over a map is o(n), but it is not optimal for caching 
+/** Iteration over a map is o(n), but it is not optimal for caching
 because the data is not stored contiguously. */
 void PhysicsManager::UpdatePhysics( float deltaTime )
 {
@@ -99,7 +109,7 @@ void PhysicsManager::UpdatePhysics( float deltaTime )
 
         entityA->ApplyForce( forceToApply );
 
-         
+
         // For each object, we need to check it against all the others 
         // in the scene that can possibly be colliding with it
         Physics::SphereCollider col1 = entityA->GetCollider();
@@ -107,7 +117,7 @@ void PhysicsManager::UpdatePhysics( float deltaTime )
 
         for ( auto innerItr = RigidBodyUIDMap.begin(); innerItr != RigidBodyUIDMap.end(); ++innerItr )
         {
-            if( innerItr->second == entityA ) continue;
+            if ( innerItr->second == entityA ) continue;
             // For each object, we need to check it against all the others 
             // in the scene that can possibly be colliding with it
             Physics::SphereCollider colOther = innerItr->second->GetCollider();
@@ -116,7 +126,7 @@ void PhysicsManager::UpdatePhysics( float deltaTime )
             {
                 //printf( "Collision!\n" );
                 // Apply a force to these objects going the oppose way
-                XMFLOAT3 difference {};
+                XMFLOAT3 difference{};
                 difference.x = ( col1.Center.x - colOther.Center.x ) * deltaTime;
                 difference.y = ( col1.Center.y - colOther.Center.y ) * deltaTime;
                 difference.z = ( col1.Center.z - colOther.Center.z ) * deltaTime;

--- a/ggp-engine/PhysicsManager.cpp
+++ b/ggp-engine/PhysicsManager.cpp
@@ -2,14 +2,13 @@
 
 #include "PhysicsManager.h"
 #include "RigidBody.h"
-#include "GameObject.h"
 
 using namespace DirectX;
 using namespace Physics;
 
 PhysicsManager* PhysicsManager::Instance = nullptr;
 
-const UINT PhysicsManager::GetRigidBodyCount() const
+const RigidBodyID PhysicsManager::GetRigidBodyCount() const
 {
     return rBodyCount;
 }
@@ -29,14 +28,14 @@ PhysicsManager::PhysicsManager()
 
 PhysicsManager::~PhysicsManager()
 {
-    for ( auto itr = RigidBodyUIDMap.begin(); itr != RigidBodyUIDMap.end(); ++itr )
+    /*for ( auto itr = RigidBodyUIDMap.begin(); itr != RigidBodyUIDMap.end(); ++itr )
     {
         RigidBody* temp = itr->second;
         if ( temp != nullptr )
         {
             delete temp;
         }
-    }
+    }*/
 }
 
 PhysicsManager* PhysicsManager::GetInstance()
@@ -56,8 +55,8 @@ void PhysicsManager::ReleaseInstance()
         Instance = nullptr;
     }
 }
-
-UINT PhysicsManager::AddRigidBody( GameObject* aGameObj, float aMass, EPhysicsLayer aLayer )
+/*
+RigidBodyID PhysicsManager::AddRigidBody( GameObject* aGameObj, float aMass, EPhysicsLayer aLayer )
 {
     assert( aGameObj );
     RigidBody* rb = new RigidBody( aGameObj, aMass, aLayer );
@@ -66,18 +65,20 @@ UINT PhysicsManager::AddRigidBody( GameObject* aGameObj, float aMass, EPhysicsLa
     Instance->RigidBodyUIDMap.insert( std::pair<UINT, RigidBody*>( Instance->rBodyCount, rb ) );
 
     return Instance->rBodyCount++;
-}
+}*/
 
-UINT Physics::PhysicsManager::AddRigidBody( GameObject * aGameObj, RigidBody * aRigidBody )
+RigidBodyID Physics::PhysicsManager::AddRigidBody( RigidBody * aRigidBody )
 {
-    assert( aRigidBody != nullptr && aGameObj != nullptr );
+    assert( aRigidBody != nullptr );
 
-    Instance->RigidBodyUIDMap.insert( std::pair<UINT, RigidBody*>( Instance->rBodyCount, aRigidBody ) );
+    Instance->RigidBodyUIDMap.insert(
+        std::pair<RigidBodyID, RigidBody*>( Instance->rBodyCount, aRigidBody ) 
+    );
 
     return Instance->rBodyCount++;
 }
 
-RigidBody * PhysicsManager::GetRigidBody( UINT uID )
+RigidBody * PhysicsManager::GetRigidBody( RigidBodyID uID )
 {
     auto thisRB = RigidBodyUIDMap.find( uID );
     //If found, return it.  Else, return nullptr

--- a/ggp-engine/PhysicsManager.h
+++ b/ggp-engine/PhysicsManager.h
@@ -3,15 +3,17 @@
 #include <map>
 #include <DirectXMath.h>
 
+#include "GameObject.h"
+
 ////////////////////////////
 // Forward Declarations
+//class GameObject;
 class RigidBody;
-class GameObject;
-enum EPhysicsLayer;
+using RigidBodyID = size_t;
 
 namespace Physics
 {
-    typedef unsigned int UINT;
+
 
     /// <summary>
     /// Control the regular updating of physics on nay rigid body objects
@@ -40,17 +42,17 @@ namespace Physics
         /// <param name="aMass">The mass of this rigidbody</param>
         /// <param name="aLayer">Physics layer of this rigidbody</param>
         /// <returns>Unique ID of this rigid body</returns>
-        UINT AddRigidBody( GameObject* aGameObj, float aMass, EPhysicsLayer aLayer );
+        //RigidBodyID AddRigidBody( GameObject* aGameObj, float aMass, EPhysicsLayer aLayer );
 
 
-        UINT AddRigidBody( GameObject* aGameObj, RigidBody* aRigidBody );
+        RigidBodyID AddRigidBody( RigidBody* aRigidBody );
 
         /// <summary>
         /// Get a rigidbody based on it's ID
         /// </summary>
         /// <param name="uID">ID to look for</param>
         /// <returns>Pointer to that rigidbody</returns>
-        RigidBody* GetRigidBody( UINT uID );
+        RigidBody* GetRigidBody( RigidBodyID uID );
 
         /// <summary>
         /// Update the physics on all rigidbodies
@@ -62,7 +64,7 @@ namespace Physics
         /// Get the current number of rigid bodies
         /// </summary>
         /// <returns>const UINT representing the number of bodies</returns>
-        const UINT GetRigidBodyCount() const;
+        const RigidBodyID GetRigidBodyCount() const;
 
         /// <summary>
         /// Send a raycast starting from the origin point in the given directoin for 
@@ -89,9 +91,9 @@ namespace Physics
         const float Gravity = -0.001f;
 
         // #Optimize
-        std::map<UINT, RigidBody*> RigidBodyUIDMap;
+        std::map<RigidBodyID, RigidBody*> RigidBodyUIDMap;
 
-        UINT rBodyCount;
+        RigidBodyID rBodyCount;
 
     };
 

--- a/ggp-engine/PhysicsManager.h
+++ b/ggp-engine/PhysicsManager.h
@@ -42,6 +42,9 @@ namespace Physics
         /// <returns>Unique ID of this rigid body</returns>
         UINT AddRigidBody( GameObject* aGameObj, float aMass, EPhysicsLayer aLayer );
 
+
+        UINT AddRigidBody( GameObject* aGameObj, RigidBody* aRigidBody );
+
         /// <summary>
         /// Get a rigidbody based on it's ID
         /// </summary>

--- a/ggp-engine/RenderManager.cpp
+++ b/ggp-engine/RenderManager.cpp
@@ -49,10 +49,20 @@ void RenderManager::Start() {
 }
 
 UINT RenderManager::AddMeshRenderer( GameObject* _gameObject) {
-	MeshRenderer* tempMR = new MeshRenderer(mrUID, _gameObject);
+	MeshRenderer* tempMR = new MeshRenderer( _gameObject);
+    tempMR->uniqueID = mrUID;
 	meshRendererUIDMap[mrUID] = tempMR;
 	mrUID++;
 	return mrUID - 1;
+}
+
+UINT RenderManager::AddMeshRenderer( MeshRenderer * _meshRenderer )
+{
+    _meshRenderer->uniqueID = mrUID;
+    meshRendererUIDMap[ mrUID ] = _meshRenderer;
+
+    mrUID++;
+    return mrUID - 1;
 }
 
 MeshRenderer* RenderManager::GetMeshRenderer(UINT _uniqueID) {
@@ -147,13 +157,13 @@ RenderManager::~RenderManager() {
 
 void RenderManager::Release() {
 	//Loop through and delete every mesh renderer
-	std::map<UINT, MeshRenderer*>::iterator mrIterator;
+	/*std::map<UINT, MeshRenderer*>::iterator mrIterator;
 	for (mrIterator = meshRendererUIDMap.begin(); mrIterator != meshRendererUIDMap.end(); ++mrIterator) {
 		MeshRenderer* mrTemp = mrIterator->second;
 		if (mrTemp != nullptr) {
 			delete mrTemp;
 		}
-	}
+	}*/
 	//Reset mesh renderer unique ID values
 	mrUID = 0;
 	//Clear the map so the singleton can be reused.

--- a/ggp-engine/RenderManager.h
+++ b/ggp-engine/RenderManager.h
@@ -65,6 +65,9 @@ public:
 	*/
 	//Create (and return the uid of) a new mesh renderer
 	UINT AddMeshRenderer( GameObject* _gameObject);
+    
+    UINT AddMeshRenderer( MeshRenderer* _meshRenderer );
+
 	//Get a mesh renderer given its unique identifier
 	MeshRenderer* GetMeshRenderer(UINT _uniqueID);
 	//Delete a mesh renderer

--- a/ggp-engine/RigidBody.cpp
+++ b/ggp-engine/RigidBody.cpp
@@ -15,11 +15,14 @@ RigidBody::RigidBody( GameObject* aGameObj, float aMass, EPhysicsLayer aPhysicsL
 
     Collider.Center = gameObject->transform.position;
     Collider.Radius = 0.2f;
+
+    Physics::PhysicsManager::GetInstance()->AddRigidBody( this );
 }
 
 RigidBody::~RigidBody()
 {
-
+    gameObject = nullptr;
+    // remove from Physics Manager
 }
 
 void RigidBody::ApplyForce( const DirectX::XMFLOAT3 & aForce )

--- a/ggp-engine/RigidBody.h
+++ b/ggp-engine/RigidBody.h
@@ -1,9 +1,10 @@
 #pragma once
-#include "Component.h"
+
 #include <DirectXMath.h>
 #include "GameObject.h"
 #include "Collisions.h"
 #include "BaseComponent.h"
+#include "PhysicsManager.h"
 
 enum EPhysicsLayer
 {
@@ -16,7 +17,7 @@ enum EPhysicsLayer
 /// </summary>
 /// <author>Ben Hoffman</author>
 class RigidBody :
-    public Component
+    public ECS::BaseComponent<RigidBody>
 {
 public:
     

--- a/ggp-engine/RigidBody.h
+++ b/ggp-engine/RigidBody.h
@@ -3,6 +3,7 @@
 #include <DirectXMath.h>
 #include "GameObject.h"
 #include "Collisions.h"
+#include "BaseComponent.h"
 
 enum EPhysicsLayer
 {


### PR DESCRIPTION
* Made the `Mesh Render` and `RigidBody` components actually extend from the `BaseComponent` class
* Remove deprecated code from the scenes 
